### PR TITLE
Statistic api

### DIFF
--- a/recipes/db.rb
+++ b/recipes/db.rb
@@ -58,4 +58,22 @@ node['xenforo']['names'].each do |db_name|
       action :grant
     end
   end
+
+  # xenforo statistic api user
+  ipaddresses = []
+  search(:node, "roles:xenforo-statistic-api AND chef_environment:#{node.chef_environment}").each do |xnode|
+    ipaddresses << xnode['ipaddress']
+  end
+
+  mysql_database_user cred['xfsapi_username'] do
+    connection mysql_connection_info
+    password cred['xfsapi_password']
+    database_name cred['dbname']
+    host ipaddresses[0]
+    privileges ['select']
+    action :grant
+
+    only_if { cred['xfsapi_username'].empty? == false }
+  end
+
 end

--- a/recipes/db.rb
+++ b/recipes/db.rb
@@ -65,15 +65,16 @@ node['xenforo']['names'].each do |db_name|
     ipaddresses << xnode['ipaddress']
   end
 
-  mysql_database_user cred['xfsapi_username'] do
-    connection mysql_connection_info
-    password cred['xfsapi_password']
-    database_name cred['dbname']
-    host ipaddresses[0]
-    privileges ['select']
-    action :grant
+  ipaddresses.each do |ipaddress|
+    next if false == cred.key?('xfsapi_username')
 
-    only_if { cred['xfsapi_username'].empty? == false }
+    mysql_database_user cred['xfsapi_username'] do
+      connection mysql_connection_info
+      password cred['xfsapi_password']
+      database_name cred['dbname']
+      host ipaddress
+      privileges ['select']
+      action :grant
+    end
   end
-
 end

--- a/test/integration/data_bags/xenforo/db.json
+++ b/test/integration/data_bags/xenforo/db.json
@@ -1,8 +1,8 @@
 {
   "id": "db",
   "vagrant": {
-    "encrypted_data": "3+pCECTqG+E8gVxXQ/U+7uoz/ayNUc1q1nbb/YrG/tXTa6vmHt8gR/YhKD0h\nbvEumYfO6/u0eVbSURKg5OP00n1ZVnAX/e6oDqCEtDorytvPY89efvxUv73o\nCRTaF+Vy1av++CQCGrkOCK9xoztHrOPYFLOhzLtM+0lF8aaUB2weFtIZBFi9\nNIxubP8SGtYN\n",
-    "iv": "H1yh7PROPoX7itLVCaqofA==\n",
+    "encrypted_data": "Ho5JKs+T5/SRZ0SjK78KX1wL+86WrOv+V+idopoedEwelAI8VuEZQo0gCDVq\nYk7GvjVDQbcltOONNexBv9EUxwuExOQic2JCVuJGVe97lS02j6UEgkbJzeUS\n/icaHE2n3rLppmOabPt22E3ceKsz+UkzH4K4RsAWqZVuXSzqo3QUI+3izOEw\ngR7FAU84q+oP\n",
+    "iv": "o3blVWjCd8jJKpXLZWxBdA==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   }

--- a/test/integration/data_bags/xenforo/db.json
+++ b/test/integration/data_bags/xenforo/db.json
@@ -1,8 +1,8 @@
 {
   "id": "db",
   "vagrant": {
-    "encrypted_data": "5xx4U+sf5rPCC+DHdFROfrOFkpweSqrseH4OmbUnPH+4xtN39XJXBWI1Bsu/\nnkOQiKl3dZlSziytED/PSsXjLQSEJ6fEs4wH9yq5u/VHCbiueN3TMKFKkJAK\ndDIjsUqB\n",
-    "iv": "JgDkOewGzjoTFpWNm54kvA==\n",
+    "encrypted_data": "3+pCECTqG+E8gVxXQ/U+7uoz/ayNUc1q1nbb/YrG/tXTa6vmHt8gR/YhKD0h\nbvEumYfO6/u0eVbSURKg5OP00n1ZVnAX/e6oDqCEtDorytvPY89efvxUv73o\nCRTaF+Vy1av++CQCGrkOCK9xoztHrOPYFLOhzLtM+0lF8aaUB2weFtIZBFi9\nNIxubP8SGtYN\n",
+    "iv": "H1yh7PROPoX7itLVCaqofA==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   }

--- a/test/integration/nodes/xenforo-statistic-api.json
+++ b/test/integration/nodes/xenforo-statistic-api.json
@@ -1,0 +1,24 @@
+{
+    "id": "xenforo-statistic-api",
+    "name": "xenforo-statistic-api",
+    "chef_environment": "_default",
+    "json_class": "Chef::Node",
+    "automatic": {
+    "hostname": "xenforo-statistic-api",
+    "os": "wheezy",
+    "ipaddress": "192.168.234.14"
+    },
+    "normal": {
+    },
+    "chef_type": "node",
+    "default": {
+    "roles": [
+        "xenforo-statistic-api"
+    ]
+    },
+    "override": {
+    },
+    "run_list": [
+        "role[xenforo-statistic-api]"
+    ]
+}

--- a/test/integration/roles/xenforo-statistic-api.json
+++ b/test/integration/roles/xenforo-statistic-api.json
@@ -1,0 +1,16 @@
+{
+    "name": "xenforo-statistic-api",
+    "description": "Xenforo statistic API",
+    "json_class": "Chef::Role",
+    "default_attributes": {
+    },
+    "override_attributes": {
+    },
+    "chef_type": "role",
+    "run_list": [
+        "recipe[restapi::default]",
+        "recipe[restapi::xfsapi]"
+    ],
+    "env_run_lists": {
+    }
+}


### PR DESCRIPTION
Added logic to create read-only user for xenforo statistic api. To activate logic, you have to add the keys: **xfsapi_username** and **xfsapi_username** at data bag xenforo db for each requested db instance.

The xenforo statist api need the role **xenforo-statistic-api** itself.